### PR TITLE
add backgroundjob to update lookup server

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -13,4 +13,7 @@
 		<nextcloud min-version="12" max-version="13" />
 	</dependencies>
 	<namespace>GlobalSiteSelector</namespace>
+	<background-jobs>
+		<job>OCA\GlobalSiteSelector\BackgroundJobs\UpdateLookupServer</job>
+	</background-jobs>
 </info>

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -25,6 +25,7 @@ namespace OCA\GlobalSiteSelector\AppInfo;
 
 use OCA\GlobalSiteSelector\GlobalSiteSelector;
 use OCA\GlobalSiteSelector\Master;
+use OCA\GlobalSiteSelector\Slave;
 use OCP\AppFramework\App;
 use OCP\AppFramework\IAppContainer;
 use OCP\Util;
@@ -41,6 +42,8 @@ class Application extends App {
 
 		if ($mode === 'master') {
 			$this->registerMasterHooks($container);
+		} else {
+			$this->registerSlaveHooks($container);
 		}
 	}
 
@@ -51,8 +54,21 @@ class Application extends App {
 	 * @param IAppContainer $c
 	 */
 	private function registerMasterHooks(IAppContainer $c) {
-		$master= $c->query(Master::class);
+		$master = $c->query(Master::class);
 		Util::connectHook('OC_User', 'pre_login', $master, 'handleLoginRequest');
+	}
+
+	/**
+	 * register hooks for the portal if it operates as a slave
+	 *
+	 * @param IAppContainer $c
+	 */
+	private function registerSlaveHooks(IAppContainer $c) {
+		$slave = $c->query(Slave::class);
+
+		Util::connectHook('OC_User', 'post_createUser',	$slave, 'createUser');
+		Util::connectHook('OC_User', 'pre_deleteUser',	$slave, 'preDeleteUser');
+		Util::connectHook('OC_User', 'post_deleteUser',	$slave, 'deleteUser');
 	}
 
 }

--- a/lib/BackgroundJobs/UpdateLookupServer.php
+++ b/lib/BackgroundJobs/UpdateLookupServer.php
@@ -75,11 +75,11 @@ class UpdateLookupServer extends Job {
 	 * @return bool
 	 */
 	protected function shouldRun() {
-		$lastRun = $this->lastRun;
+		$lastRun = (int)$this->lastRun;
 		$currentTime = time();
 
 		// update every 24 hours and only if the app runs in slave mode
-		if ($this->operationMode !== 'slave' || $lastRun > $currentTime - 86400) {
+		if ($this->slave->getOperationMode() !== 'slave' || $lastRun > $currentTime - 86400) {
 			return false;
 		}
 

--- a/lib/BackgroundJobs/UpdateLookupServer.php
+++ b/lib/BackgroundJobs/UpdateLookupServer.php
@@ -1,0 +1,191 @@
+<?php
+/**
+ * @copyright Copyright (c) 2017 Bjoern Schiessle <bjoern@schiessle.org>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+
+namespace OCA\GlobalSiteSelector\BackgroundJobs;
+
+
+use OC\Accounts\AccountManager;
+use OC\BackgroundJob\Job;
+use OCA\GlobalSiteSelector\GlobalSiteSelector;
+use OCP\BackgroundJob\IJobList;
+use OCP\Http\Client\IClientService;
+use OCP\ILogger;
+use OCP\IUser;
+use OCP\IUserManager;
+
+class UpdateLookupServer extends Job {
+
+	/** @var IUserManager */
+	private $userManager;
+
+	/** @var AccountManager */
+	private $accountManager;
+
+	/** @var IClientService */
+	private $clientService;
+
+	/** @var ILogger */
+	private $logger;
+
+	/** @var string */
+	private $lookupServer;
+
+	/** @var string */
+	private $operationMode;
+
+	/** @var string */
+	private $authKey;
+
+	/**
+	 * UpdateLookupServer constructor.
+	 *
+	 * @param IUserManager $userManager
+	 * @param AccountManager $accountManager
+	 * @param IClientService $clientService
+	 * @param GlobalSiteSelector $gss
+	 * @param ILogger $logger
+	 */
+	public function __construct(IUserManager $userManager,
+								AccountManager $accountManager,
+								IClientService $clientService,
+								GlobalSiteSelector $gss,
+								ILogger $logger) {
+		$this->userManager = $userManager;
+		$this->accountManager = $accountManager;
+		$this->clientService = $clientService;
+		$this->logger = $logger;
+		$this->lookupServer = $gss->getLookupServerUrl();
+		$this->operationMode = $gss->getMode();
+		$this->authKey = $gss->getJwtKey();
+		$this->lookupServer = rtrim($this->lookupServer, '/');
+		$this->lookupServer .= '/gs/users';
+	}
+
+	protected function run($argument) {
+		$backends = $this->userManager->getBackends();
+		foreach ($backends as $backend) {
+			$limit = 200;
+			$offset = 0;
+			$batch = ['authKey' => $this->authKey, 'users' => []];
+
+			do {
+				$users = $backend->getUsers('', $limit, $offset);
+				foreach ($users as $uid) {
+					$user = $this->userManager->get($uid);
+					if ($user !== null) {
+						$batch['users'][$user->getCloudId()] = $this->getAccountData($user);
+					}
+				}
+				$offset += $limit;
+				$this->sendBatch($batch);
+			} while (count($users) >= $limit);
+		}
+	}
+
+	/**
+	 * run the job, then remove it from the jobList
+	 *
+	 * @param JobList $jobList
+	 * @param ILogger|null $logger
+	 */
+	public function execute($jobList, ILogger $logger = null) {
+
+		if ($this->shouldRun()) {
+			parent::execute($jobList, $logger);
+		}
+	}
+
+	/**
+	 * re-add background job with updated arguments
+	 *
+	 * @param IJobList $jobList
+	 */
+	protected function reAddJob(IJobList $jobList) {
+		$jobList->add(UpdateLookupServer::class, ['lastRun' => time()]);
+	}
+
+	/**
+	 * check if it is time for the next update (update happens every 24 hours)
+	 *
+	 * @return bool
+	 */
+	protected function shouldRun() {
+		$lastRun = $this->lastRun;
+		$currentTime = time();
+
+		if (empty($this->lookupServer)
+			|| empty($this->operationMode)
+			|| empty($this->authKey)
+		) {
+			$this->logger->error('globle side selector app not configured correctly', ['app' => 'globalsiteselector']);
+			return false;
+		}
+
+
+		// update every 24 hours and only if the app runs in slave mode
+		if ($this->operationMode !== 'slave' || $lastRun > $currentTime - 86400) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * get user data from account manager
+	 *
+	 * @param IUser $user
+	 * @return array
+	 */
+	protected function getAccountData(IUser $user) {
+		$rawData = $this->accountManager->getUser($user);
+		$data = [];
+		foreach ($rawData as $key => $value) {
+			if ($key === 'displayname') {
+				$data['name'] = $value['value'];
+			} else {
+				$data[$key] = $value['value'];
+			}
+		}
+		unset($data['avatar']);
+		return $data;
+	}
+
+	/**
+	 * data send to the lookup server
+	 *
+	 * @param $dataBatch
+	 */
+	protected function sendBatch($dataBatch) {
+		$httpClient = $this->clientService->newClient();
+		try {
+			$httpClient->post($this->lookupServer,
+				[
+					'body' => json_encode($dataBatch),
+					'timeout' => 10,
+					'connect_timeout' => 3,
+				]
+			);
+		} catch (\Exception $e) {
+			$this->logger->warning('Could not send user to lookup server, will retry later');
+		}
+	}
+}

--- a/lib/BackgroundJobs/UpdateLookupServer.php
+++ b/lib/BackgroundJobs/UpdateLookupServer.php
@@ -23,82 +23,28 @@
 namespace OCA\GlobalSiteSelector\BackgroundJobs;
 
 
-use OC\Accounts\AccountManager;
 use OC\BackgroundJob\Job;
-use OCA\GlobalSiteSelector\GlobalSiteSelector;
+use OCA\GlobalSiteSelector\Slave;
 use OCP\BackgroundJob\IJobList;
-use OCP\Http\Client\IClientService;
 use OCP\ILogger;
-use OCP\IUser;
-use OCP\IUserManager;
 
 class UpdateLookupServer extends Job {
 
-	/** @var IUserManager */
-	private $userManager;
+	/** @var Slave */
+	private $slave;
 
-	/** @var AccountManager */
-	private $accountManager;
-
-	/** @var IClientService */
-	private $clientService;
-
-	/** @var ILogger */
-	private $logger;
-
-	/** @var string */
-	private $lookupServer;
-
-	/** @var string */
-	private $operationMode;
-
-	/** @var string */
-	private $authKey;
 
 	/**
 	 * UpdateLookupServer constructor.
 	 *
-	 * @param IUserManager $userManager
-	 * @param AccountManager $accountManager
-	 * @param IClientService $clientService
-	 * @param GlobalSiteSelector $gss
-	 * @param ILogger $logger
+	 * @param Slave $slave
 	 */
-	public function __construct(IUserManager $userManager,
-								AccountManager $accountManager,
-								IClientService $clientService,
-								GlobalSiteSelector $gss,
-								ILogger $logger) {
-		$this->userManager = $userManager;
-		$this->accountManager = $accountManager;
-		$this->clientService = $clientService;
-		$this->logger = $logger;
-		$this->lookupServer = $gss->getLookupServerUrl();
-		$this->operationMode = $gss->getMode();
-		$this->authKey = $gss->getJwtKey();
-		$this->lookupServer = rtrim($this->lookupServer, '/');
-		$this->lookupServer .= '/gs/users';
+	public function __construct(Slave $slave) {
+		$this->slave = $slave;
 	}
 
 	protected function run($argument) {
-		$backends = $this->userManager->getBackends();
-		foreach ($backends as $backend) {
-			$limit = 200;
-			$offset = 0;
-			$batch = ['authKey' => $this->authKey, 'users' => []];
-
-			do {
-				$users = $backend->getUsers('', $limit, $offset);
-				foreach ($users as $uid) {
-					$user = $this->userManager->get($uid);
-					if ($user !== null) {
-						$batch['users'][$user->getCloudId()] = $this->getAccountData($user);
-					}
-				}
-				$offset += $limit;
-				$this->sendBatch($batch);
-			} while (count($users) >= $limit);
-		}
+		$this->slave->batchUpdate();
 	}
 
 	/**
@@ -132,60 +78,11 @@ class UpdateLookupServer extends Job {
 		$lastRun = $this->lastRun;
 		$currentTime = time();
 
-		if (empty($this->lookupServer)
-			|| empty($this->operationMode)
-			|| empty($this->authKey)
-		) {
-			$this->logger->error('globle side selector app not configured correctly', ['app' => 'globalsiteselector']);
-			return false;
-		}
-
-
 		// update every 24 hours and only if the app runs in slave mode
 		if ($this->operationMode !== 'slave' || $lastRun > $currentTime - 86400) {
 			return false;
 		}
 
 		return true;
-	}
-
-	/**
-	 * get user data from account manager
-	 *
-	 * @param IUser $user
-	 * @return array
-	 */
-	protected function getAccountData(IUser $user) {
-		$rawData = $this->accountManager->getUser($user);
-		$data = [];
-		foreach ($rawData as $key => $value) {
-			if ($key === 'displayname') {
-				$data['name'] = $value['value'];
-			} else {
-				$data[$key] = $value['value'];
-			}
-		}
-		unset($data['avatar']);
-		return $data;
-	}
-
-	/**
-	 * data send to the lookup server
-	 *
-	 * @param $dataBatch
-	 */
-	protected function sendBatch($dataBatch) {
-		$httpClient = $this->clientService->newClient();
-		try {
-			$httpClient->post($this->lookupServer,
-				[
-					'body' => json_encode($dataBatch),
-					'timeout' => 10,
-					'connect_timeout' => 3,
-				]
-			);
-		} catch (\Exception $e) {
-			$this->logger->warning('Could not send user to lookup server, will retry later');
-		}
 	}
 }

--- a/lib/GlobalSiteSelector.php
+++ b/lib/GlobalSiteSelector.php
@@ -67,10 +67,19 @@ class GlobalSiteSelector {
 	/**
 	 * get the URL of the global site selector master
 	 *
-	 * @return mixed
+	 * @return string
 	 */
 	public function getMasterUrl() {
 		return $this->config->getSystemValue('gss.master.url', '');
+	}
+
+	/**
+	 * get lookup server URL
+	 *
+	 * @return string
+	 */
+	public function getLookupServerUrl() {
+		return $this->config->getSystemValue('lookup_server', '');
 	}
 
 }

--- a/lib/Slave.php
+++ b/lib/Slave.php
@@ -100,7 +100,7 @@ class Slave {
 	}
 
 	/**
-	 * the server indicated that the admin want to remove the server, remember the
+	 * the server indicated that the admin want to remove a user, remember the
 	 * federated cloud id so that we can remove the user from the lookup server
 	 * once they were deleted
 	 *

--- a/lib/Slave.php
+++ b/lib/Slave.php
@@ -1,0 +1,236 @@
+<?php
+/**
+ * @copyright Copyright (c) 2017 Bjoern Schiessle <bjoern@schiessle.org>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+
+namespace OCA\GlobalSiteSelector;
+
+
+use OC\Accounts\AccountManager;
+use OCP\Http\Client\IClientService;
+use OCP\ILogger;
+use OCP\IUser;
+use OCP\IUserManager;
+
+class Slave {
+
+	/** @var AccountManager */
+	private $accountManager;
+
+	/** @var IUserManager */
+	private $userManager;
+
+	/** @var IClientService */
+	private $clientService;
+
+	/** @var ILogger */
+	private $logger;
+
+	/** @var string */
+	private $lookupServer;
+
+	/** @var string */
+	private $operationMode;
+
+	/** @var string */
+	private $authKey;
+
+	/**
+	 * remember users which should be removed
+	 *
+	 * @var array
+	 */
+	private static $toRemove = [];
+
+	/**
+	 * Slave constructor.
+	 *
+	 * @param AccountManager $accountManager
+	 * @param IUserManager $userManager
+	 * @param IClientService $clientService
+	 * @param GlobalSiteSelector $gss
+	 * @param ILogger $logger
+	 */
+	public function __construct(AccountManager $accountManager,
+								IUserManager $userManager,
+								IClientService $clientService,
+								GlobalSiteSelector $gss,
+								ILogger $logger
+	) {
+		$this->accountManager = $accountManager;
+		$this->userManager = $userManager;
+		$this->clientService = $clientService;
+		$this->logger = $logger;
+		$this->lookupServer = $gss->getLookupServerUrl();
+		$this->operationMode = $gss->getMode();
+		$this->authKey = $gss->getJwtKey();
+		$this->lookupServer = rtrim($this->lookupServer, '/');
+		$this->lookupServer .= '/gs/users';
+	}
+
+	public function createUser(array $params) {
+		if ($this->checkConfiguration() === false)  {
+			return;
+		}
+
+		$uid = $params['uid'];
+		$user = $this->userManager->get($uid);
+		$userData = [];
+		if ($user !== null) {
+			$userData[$user->getCloudId()] = $this->getAccountData($user);
+			$this->addUsers($userData);
+		}
+	}
+
+	/**
+	 * the server indicated that the admin want to remove the server, remember the
+	 * federated cloud id so that we can remove the user from the lookup server
+	 * once they were deleted
+	 *
+	 * @param array $params
+	 */
+	public function preDeleteUser(array $params) {
+		$uid = $params['uid'];
+		$user = $this->userManager->get($uid);
+		if ($user !== null) {
+			self::$toRemove[$uid] = $user->getCloudId();
+		}
+	}
+
+	/**
+	 * remove user from lookup server
+	 *
+	 * @param array $params
+	 */
+	public function deleteUser(array $params) {
+		if ($this->checkConfiguration() === false)  {
+			return;
+		}
+
+		$uid = $params['uid'];
+		if (isset(self::$toRemove[$uid])) {
+			$this->removeUsers([self::$toRemove[$uid]]);
+			unset(self::$toRemove[$uid]);
+		}
+	}
+
+	/**
+	 * update the lookup server with all known users on this instance. This
+	 * is triggered by a cronjob
+	 */
+	public function batchUpdate() {
+		if ($this->checkConfiguration() === false)  {
+			return;
+		}
+
+		$backends = $this->userManager->getBackends();
+		foreach ($backends as $backend) {
+			$limit = 200;
+			$offset = 0;
+			$usersData = [];
+			do {
+				$users = $backend->getUsers('', $limit, $offset);
+				foreach ($users as $uid) {
+					$user = $this->userManager->get($uid);
+					if ($user !== null) {
+						$usersData[$user->getCloudId()] = $this->getAccountData($user);
+					}
+				}
+				$offset += $limit;
+				$this->addUsers($usersData);
+			} while (count($users) >= $limit);
+		}
+	}
+
+	/**
+	 * get user data from account manager
+	 *
+	 * @param IUser $user
+	 * @return array
+	 */
+	protected function getAccountData(IUser $user) {
+		$rawData = $this->accountManager->getUser($user);
+		$data = [];
+		foreach ($rawData as $key => $value) {
+			if ($key === 'displayname') {
+				$data['name'] = $value['value'];
+			} else {
+				$data[$key] = $value['value'];
+			}
+		}
+		unset($data['avatar']);
+		return $data;
+	}
+
+	/**
+	 * send users to the lookup server
+	 *
+	 * @param array $users
+	 */
+	protected function addUsers(array $users) {
+		$dataBatch = ['authKey' => $this->authKey, 'users' => $users];
+
+		$httpClient = $this->clientService->newClient();
+		try {
+			$httpClient->post($this->lookupServer,
+				[
+					'body' => json_encode($dataBatch),
+					'timeout' => 10,
+					'connect_timeout' => 3,
+				]
+			);
+		} catch (\Exception $e) {
+			$this->logger->warning('Could not send user to lookup server');
+		}
+	}
+
+	/**
+	 * remove users from the lookup server
+	 *
+	 * @param array $users
+	 */
+	protected function removeUsers(array $users) {
+		$dataBatch = ['authKey' => $this->authKey, 'users' => $users];
+
+		$httpClient = $this->clientService->newClient();
+		try {
+			$httpClient->delete($this->lookupServer,
+				[
+					'body' => json_encode($dataBatch),
+					'timeout' => 10,
+					'connect_timeout' => 3,
+				]
+			);
+		} catch (\Exception $e) {
+			$this->logger->warning('Could not remove user from the lookup server');
+		}
+	}
+
+	protected function checkConfiguration() {
+		if (empty($this->lookupServer)
+			|| empty($this->operationMode)
+			|| empty($this->authKey)
+		) {
+			$this->logger->error('globle side selector app not configured correctly', ['app' => 'globalsiteselector']);
+			return false;
+		}
+
+	}
+}

--- a/lib/Slave.php
+++ b/lib/Slave.php
@@ -233,4 +233,12 @@ class Slave {
 		}
 
 	}
+
+	/**
+	 * Operation mode - slave or master
+	 * @return string
+	 */
+	public function getOperationMode() {
+		return $this->operationMode;
+	}
 }

--- a/tests/unit/lib/GlobalSiteSelectorTest.php
+++ b/tests/unit/lib/GlobalSiteSelectorTest.php
@@ -69,4 +69,13 @@ class GlobalSiteSelectorTest extends TestCase {
 		$this->assertSame('result', $result);
 	}
 
+	public function testGetLookupServerUrl() {
+		$this->config->expects($this->once())->method('getSystemValue')
+			->with('lookup_server', '')->willReturn('result');
+
+		$result = $this->gss->getLookupServerUrl();
+
+		$this->assertSame('result', $result);
+	}
+
 }


### PR DESCRIPTION
- update lookup server every 24 hours.
- listen to create/delete user events to update the lookup server immediately if the local user backend is used

cc @MorrisJobke 