### PR TITLE
Initial user discovery modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,8 +52,6 @@ matrix:
     - php: 7.0
       env: DB=pgsql
     - php: 7.0
-      env: DB=mysql;CODECHECK=1
-    - php: 7.0
       env: DB=mysql;CODECHECK=2
   allow_failures:
     - env: DB=mysql;CODECHECK=2

--- a/README.md
+++ b/README.md
@@ -26,8 +26,13 @@ Config.php parameters to operate the server in master mode:
 // allowed to login at the master node to perform administration tasks
 'gss.master.admin' => ['admin1Uid', 'admin2Uid'],
 
-// define a parameter given by the IdP to decide where a user is located
-'gss.saml.slave.mapping' => 'idpParameterSlave',
+// define a class which will be used to decide on which server a user should be
+// provisioned in case the lookup server doesn't know the user yet.
+// Note: That this will create a user account on a global scale note for every user
+//       so make sure that the Global Site Selector has verified if it is a valid user before.
+//       The user disovery module might require additional config paramters you can find in
+//       the documentation of the module
+'gss.user.discovery.module' => '\OCA\GlobalSiteSelector\UserDiscoveryModules\UserDiscoverySAML',
 ````
 
 ### Slave
@@ -46,3 +51,45 @@ Config parameters to operate the server in slave mode:
 'gss.master.url' => 'http://localhost/nextcloud2',
 ````
 
+### User Discovery Modules
+
+When users login for the first time and is not yet known by the lookup server,
+different methods are possible to decide on which server the user should be located.
+
+The GlobalSiteSelector allows you to use one of the existing methods or implementing
+your own, based on the `IUserDiscoveryModule` interface.
+
+To define which of the modules should be used you can set the `gss.user.discovery.module`
+parameter as described above.
+
+Following modules exists at the moment, some of the are highly customized for a
+specific use case:
+
+#### UserDiscoverySAML
+
+This modules reads the location directly from a parameter of the IDP which contain
+the exact URL to the server. The name of the parameter can be defined this way:
+
+````
+'gss.discovery.saml.slave.mapping' => 'idp-parameter'
+````
+
+#### ManualUserMapping
+
+This allows you to maintain a custom json file which maps a specific key word
+to a nextcloud server. The json file looks like this:
+
+````
+{
+  "keyword1" : "https://server1.nextcloud.com",
+  "keyword2" : "https://server2.nextcloud.com"
+}
+
+````
+
+The additional parameters you need to specify in the config.php are the following:
+
+````
+'gss.discovery.manual.mapping.file' => '/path/to/file'
+'gss.discovery.manual.mapping.parameter' => 'idp-parameter'
+````

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -5,7 +5,7 @@
 	<name>Global Site Selector</name>
 	<summary>Nextcloud Portal to redirect users to the right instance</summary>
 	<description>The Global Site Selector allows you to run multiple small Nextcloud instances and redirect users to the right server</description>
-	<version>1.0.0</version>
+	<version>1.0.1</version>
 	<licence>agpl</licence>
 	<author>Bjoern Schiessle</author>
 	<namespace>GlobalSiteSelector</namespace>

--- a/lib/Migration/Version0110Date20180925143400.php
+++ b/lib/Migration/Version0110Date20180925143400.php
@@ -58,7 +58,7 @@ class Version0110Date20180925143400 extends SimpleMigrationStep {
 			]);
 
 			$table->setPrimaryKey(['id']);
-			$table->addIndex(['uid'], 'gss_uid');
+			$table->addIndex(['uid'], 'gss_uid_index');
 		}
 
 		return $schema;

--- a/lib/UserDiscoveryModules/IUserDiscoveryModule.php
+++ b/lib/UserDiscoveryModules/IUserDiscoveryModule.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * @copyright Copyright (c) 2018 Bjoern Schiessle <bjoern@schiessle.org>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\GlobalSiteSelector\UserDiscoveryModules;
+
+interface IUserDiscoveryModule {
+
+	/**
+	 * get the initial user location
+	 *
+	 * @param array $data arbitrary data, whatever the module needs (for example for SAML we hand over the raw data)
+	 * @return string
+	 */
+	public function getLocation($data);
+}

--- a/lib/UserDiscoveryModules/ManualUserMapping.php
+++ b/lib/UserDiscoveryModules/ManualUserMapping.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * @copyright Copyright (c) 2018 Bjoern Schiessle <bjoern@schiessle.org>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\GlobalSiteSelector\UserDiscoveryModules;
+use OCP\IConfig;
+
+/**
+ * Class ManualUserMapping
+ *
+ * allows you to manage a local file which maps a arbitrary SAML parameter to
+ * a initial location of the user.
+ *
+ * Therefore you have to define to values in the config.php
+ *
+ * 'gss.discovery.manual.mapping.file' => '/path/to/file'
+ * 'gss.discovery.manual.mapping.parameter' => 'idp-parameter'
+ *
+ * @package OCA\GlobalSiteSelector\UserDiscoveryModules
+ */
+class ManualUserMapping implements IUserDiscoveryModule {
+
+	/** @var string */
+	private $idpParameter;
+	/** @var string */
+	private $file;
+
+	/**
+	 * ManualUserMapping constructor.
+	 *
+	 * @param IConfig $config
+	 */
+	public function __construct(IConfig $config) {
+		$this->idpParameter = $config->getSystemValue('gss.discovery.manual.mapping.parameter', '');
+		$this->file = $config->getSystemValue('gss.discovery.manual.mapping.file', '');
+	}
+
+
+	/**
+	 * get the initial user location
+	 *
+	 * @param array $data arbitrary data, whatever the module needs
+	 * @return string
+	 */
+	public function getLocation($data) {
+
+		$location = '';
+		$dictionary = $this->getDictionary();
+		$key = $this->getKey($data);
+
+		if (!empty($key) && is_array($dictionary)) {
+			$location = isset($dictionary[$key]) ? $dictionary[$key] : '';
+		}
+
+		return $location;
+	}
+
+	/**
+	 * get dictionary which maps idp parameters to nextcloud nodes
+	 *
+	 * @return array
+	 */
+	private function getDictionary() {
+		$dictionary = [];
+		$isValidFile = !empty($this->file) && file_exists($this->file);
+		if ($isValidFile) {
+			$mapString = file_get_contents($this->file);
+			$dictionary = json_decode($mapString, true);
+		}
+
+		return is_array($dictionary) ? $dictionary : [];
+	}
+
+	/**
+	 * get key from IDP parameter
+	 *
+	 * @param array $data idp parameters
+	 * @return string
+	 */
+	private function getKey($data) {
+		$key = '';
+		if (!empty($this->idpParameter) && isset($data['saml'][$this->idpParameter][0])) {
+			$key = $data['saml'][$this->idpParameter][0];
+		}
+
+		return $this->normalizeKey($key);
+	}
+
+	/**
+	 * the keys are build like email addresses, we only need the "domain part"
+	 *
+	 * @param $key
+	 * @return string
+	 */
+	private function normalizeKey($key) {
+		$normalized = '';
+		$pos = strrpos($key, '@');
+		if ($pos !== false) {
+			$normalized = substr($key, $pos+1);
+		}
+		return $normalized;
+	}
+}

--- a/lib/UserDiscoveryModules/UserDiscoverySAML.php
+++ b/lib/UserDiscoveryModules/UserDiscoverySAML.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * @copyright Copyright (c) 2018 Bjoern Schiessle <bjoern@schiessle.org>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\GlobalSiteSelector\UserDiscoveryModules;
+use OCP\IConfig;
+
+/**
+ * Class UserDiscoverySAML
+ *
+ * discover initial user location with a dedicated SAML parameter
+ *
+ * Therefore you have to define to values in the config.php
+ *
+ * 'gss.discovery.saml.slave.mapping' => 'idp-parameter'
+ *
+ * @package OCA\GlobalSiteSelector\UserDiscoveryModule
+ */
+class UserDiscoverySAML implements IUserDiscoveryModule {
+
+	/** @var string */
+	private $idpParameter;
+
+	/**
+	 * UserDiscoverySAML constructor.
+	 *
+	 * @param IConfig $config
+	 */
+	public function __construct(IConfig $config) {
+		$this->idpParameter = $config->getSystemValue('gss.discovery.saml.slave.mapping', '');
+	}
+
+
+	/**
+	 * read user location from SAML parameters
+	 *
+	 * @param array $data SAML Parameters to read the location from
+	 * @return string
+	 */
+	public function getLocation($data) {
+		$location = '';
+		if (!empty($this->idpParameter) && isset($data['saml'][$this->idpParameter][0])) {
+			$location = $data['saml'][$this->idpParameter][0];
+		}
+
+		return $location;
+	}
+
+}

--- a/tests/unit/lib/MasterTest.php
+++ b/tests/unit/lib/MasterTest.php
@@ -27,8 +27,10 @@ use Firebase\JWT\JWT;
 use OCA\GlobalSiteSelector\GlobalSiteSelector;
 use OCA\GlobalSiteSelector\Lookup;
 use OCA\GlobalSiteSelector\Master;
+use OCP\AppFramework\IAppContainer;
 use OCP\Http\Client\IClientService;
 use OCP\IConfig;
+use OCP\ILogger;
 use OCP\IRequest;
 use OCP\Security\ICrypto;
 use Test\TestCase;
@@ -53,6 +55,12 @@ class MasterTest extends TestCase {
 	/** @var IConfig | \PHPUnit_Framework_MockObject_MockObject */
 	private $config;
 
+	/** @var \PHPUnit_Framework_MockObject_MockObject|ILogger */
+	private $logger;
+
+	/** @var \PHPUnit_Framework_MockObject_MockObject|IAppContainer */
+	private $container;
+
 	public function setUp() {
 		parent::setUp();
 
@@ -64,6 +72,8 @@ class MasterTest extends TestCase {
 		$this->request = $this->createMock(IRequest::class);
 		$this->clientService = $this->createMock(IClientService::class);
 		$this->config = $this->createMock(IConfig::class);
+		$this->logger = $this->createMock(ILogger::class);
+		$this->container = $this->createMock(IAppContainer::class);
 	}
 
 	/**
@@ -79,7 +89,9 @@ class MasterTest extends TestCase {
 					$this->lookup,
 					$this->request,
 					$this->clientService,
-					$this->config
+					$this->config,
+					$this->logger,
+					$this->container
 				]
 			)->setMethods($mockMethods)->getMock();
 	}


### PR DESCRIPTION
Allow to have individual/custom user discovery modules to deploy the user on a specific nextcloud node during first login if the lookup server doesn't know the user yet.