### PR TITLE
Fix client login

### DIFF
--- a/lib/Controller/SlaveController.php
+++ b/lib/Controller/SlaveController.php
@@ -179,7 +179,6 @@ class SlaveController extends OCSController {
 	 * Create app token
 	 *
 	 * @PublicPage
-	 * @NoCSRFRequired
 	 * @NoAdminRequired
 	 *
 	 * @return DataResponse

--- a/lib/Controller/SlaveController.php
+++ b/lib/Controller/SlaveController.php
@@ -178,23 +178,32 @@ class SlaveController extends OCSController {
 	/**
 	 * Create app token
 	 *
+	 * @PublicPage
+	 * @NoCSRFRequired
 	 * @NoAdminRequired
 	 *
 	 * @return DataResponse
 	 */
-	public function createAppToken() {
+	public function createAppToken($jwt) {
 
-		if($this->gss->getMode() === 'master') {
+		if($this->gss->getMode() === 'master' || empty($jwt)) {
 			return new DataResponse([], Http::STATUS_BAD_REQUEST);
 		}
 
-		$user = $this->userSession->getUser();
-		$uid = $user->getUID();
+		try {
+			list($uid, $password, $options) = $this->decodeJwt($jwt);
 
-		$token = $this->tokenHandler->generateAppToken($uid);
+			if ($this->userManager->userExists($uid)) {
+				$token = $this->tokenHandler->generateAppToken($uid);
+				return new DataResponse($token);
+			}
+		}  catch (ExpiredException $e) {
+			$this->logger->info('Create app password: JWT token expired', ['app' => 'globalsiteselector']);
+		} catch (\Exception $e) {
+			$this->logger->logException('Create app password: ' . $e, ['app' => 'globalsiteselector']);
+		}
 
-		return new DataResponse($token);
-
+		return new DataResponse([], Http::STATUS_BAD_REQUEST);
 
 	}
 

--- a/lib/Controller/SlaveController.php
+++ b/lib/Controller/SlaveController.php
@@ -194,8 +194,16 @@ class SlaveController extends OCSController {
 			list($uid, $password, $options) = $this->decodeJwt($jwt);
 
 			if ($this->userManager->userExists($uid)) {
-				$token = $this->tokenHandler->generateAppToken($uid);
-				return new DataResponse($token);
+				// if we have a password, we verify it
+				if (!empty($password)) {
+					$result = $this->userSession->login($uid, $password);
+				} else {
+					$result = true;
+				}
+				if ($result) {
+					$token = $this->tokenHandler->generateAppToken($uid);
+					return new DataResponse($token);
+				}
 			}
 		}  catch (ExpiredException $e) {
 			$this->logger->info('Create app password: JWT token expired', ['app' => 'globalsiteselector']);

--- a/lib/Master.php
+++ b/lib/Master.php
@@ -202,7 +202,12 @@ class Master {
 			]
 		);
 
-		if($isClient) {
+		$requestUri = $this->request->getRequestUri();
+		$isDirectWebDavAccess = strpos($requestUri, 'remote.php/webdav') !== false;
+		// direct webdav access with old client or general purpose webdav clients
+		if ($isClient && $isDirectWebDavAccess) {
+			$redirectUrl = $location . '/remote.php/webdav/';
+		} else if($isClient && !$isDirectWebDavAccess) {
 			$appToken = $this->getAppToken($location, $uid, $password);
 			$redirectUrl = 'nc://login/server:' . $location . '&user:' . $uid . '&password:' . $appToken;
 		} else {

--- a/lib/Master.php
+++ b/lib/Master.php
@@ -246,13 +246,17 @@ class Master {
 	 */
 	protected function getAppToken($location, $uid, $password) {
 		$client = $this->clientService->newClient();
+		$jwt = $this->createJwt($uid, $password, []);
 
-		$baseUrl = $this->buildBasicAuthUrl($location, $uid, $password);
 		$response = $client->get(
-			$baseUrl . '/ocs/v2.php/apps/globalsiteselector/v1/createapptoken?format=json',
+			$location . '/ocs/v2.php/apps/globalsiteselector/v1/createapptoken',
 			[
 				'headers' => [
 					'OCS-APIRequest' => 'true'
+				],
+				'query' => [
+					'format' => 'json',
+					'jwt' => $jwt
 				]
 			]
 		);

--- a/lib/Master.php
+++ b/lib/Master.php
@@ -203,7 +203,9 @@ class Master {
 		);
 
 		$requestUri = $this->request->getRequestUri();
+		// check for both possible direct webdav end-points
 		$isDirectWebDavAccess = strpos($requestUri, 'remote.php/webdav') !== false;
+		$isDirectWebDavAccess = $isDirectWebDavAccess || strpos($requestUri, 'remote.php/dav') !== false;
 		// direct webdav access with old client or general purpose webdav clients
 		if ($isClient && $isDirectWebDavAccess) {
 			$redirectUrl = $location . '/remote.php/webdav/';

--- a/lib/UserBackend.php
+++ b/lib/UserBackend.php
@@ -329,8 +329,8 @@ class UserBackend implements IUserBackend, UserInterface {
 		// master and forwarded to the client the uid is stored in the session.
 		// In this case we can trust the global site selector that the password was
 		// checked.
-		$uid = $this->session->get('globalScale.uid');
-		if ($uid === $uid) {
+		$currentUid = $this->session->get('globalScale.uid');
+		if ($currentUid === $uid) {
 			return $uid;
 		}
 


### PR DESCRIPTION
Right now we get the app token from the Nextcloud server with a ocs request using basic auth. But in case of saml we don't have a username/password to perform baisc auth.

So what I do here is I use the JWT we use far all the other requests between GSS and clients to authenticate and if a valid JWT was send we allow the GSS to request the app token for the given user.

- [x] Works with the new client and mobile
- [x]  Works with the old client

@MorrisJobke do I miss anything in any special scenario? This should always work, right?
@rullzer what do you think from the client point of view