### PR TITLE
redirect to correct sub-page

### DIFF
--- a/lib/Controller/SlaveController.php
+++ b/lib/Controller/SlaveController.php
@@ -140,6 +140,8 @@ class SlaveController extends OCSController {
 
 			list($uid, $password, $options) = $this->decodeJwt($jwt);
 
+			$target = $options['target'];
+
 			if(is_array($options) && isset($options['backend']) && $options['backend'] === 'saml') {
 				$this->autoprovisionIfNeeded($uid, $options);
 				try {
@@ -170,7 +172,7 @@ class SlaveController extends OCSController {
 		}
 
 		$this->userSession->createSessionToken($this->request, $uid, $uid, null, 0);
-		$home = $this->urlGenerator->getAbsoluteURL('/');
+		$home = $this->urlGenerator->getAbsoluteURL($target);
 		return new RedirectResponse($home);
 
 	}

--- a/lib/Master.php
+++ b/lib/Master.php
@@ -112,7 +112,7 @@ class Master {
 			return;
 		}
 
-		$target = $this->request->getPathInfo() === false ? '/' : $this->request->getPathInfo();
+		$target = $this->request->getPathInfo() === false ? '/' : '/index.php' . $this->request->getPathInfo();
 
 		$options = ['target' => $target];
 		$discoveryData = [];

--- a/lib/Master.php
+++ b/lib/Master.php
@@ -112,7 +112,9 @@ class Master {
 			return;
 		}
 
-		$options = [];
+		$target = $this->request->getPathInfo() === false ? '/' : $this->request->getPathInfo();
+
+		$options = ['target' => $target];
 		$discoveryData = [];
 
 		$userDiscoveryModule = $this->config->getSystemValue('gss.user.discovery.module', '');


### PR DESCRIPTION
The idea is that if someone clicks for example on a link with the url `http://<nextcloud-global-site-selector>/index.php/settings/user/security`, they should be redirected to the same page of the actual nextcloud node after login.

The code works it theory. But in my dev setup the URL created at the target server is `http://<nextcloud-node/settings/user/security` without the "index.php" which will result in an error. Any idea how to fix it? Should I use something else then `$this->urlGenerator->getAbsoluteURL($target);`?

cc @MorrisJobke @rullzer 