### PR TITLE
redirect user to the Global Site Selector if they are not logged in

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ Config parameters to operate the server in slave mode:
 'gss.master.url' => 'http://localhost/nextcloud2',
 ````
 
+The Slave will always redirect not logged in user to the master to perform the login.
+If you want to login directly at a slave, e.g. to perform some administration tasks
+you can call the login page with the parameter `?direct=1`, e.g. `https://node1.myorg.com?direct=1`
+
 ### User Discovery Modules
 
 When users login for the first time and is not yet known by the lookup server,

--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -44,6 +44,10 @@ if (!$userSession->isLoggedIn() && !empty($masterUrl) &&
 		return;
 	}
 
+	if(isset($params['redirect_url'])) {
+		$masterUrl .= $params['redirect_url'];
+	}
+
 	header('Location: '. $masterUrl);
 	exit();
 }

--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -26,9 +26,24 @@ $app = new \OCA\GlobalSiteSelector\AppInfo\Application();
 if(OC::$CLI) {
 	return;
 }
-
 $config = \OC::$server->getConfig();
 $gssMode = $config->getSystemValue('gss.mode', '');
 if ($gssMode === 'master') {
 	return;
+}
+
+$userSession = \OC::$server->getUserSession();
+$masterUrl = $config->getSystemValue('gss.master.url', '');
+$request = \OC::$server->getRequest();
+if (!$userSession->isLoggedIn() && !empty($masterUrl) &&
+	$request->getPathInfo() === '/login') {
+
+	// an admin wants to login directly at the Nextcloud node
+	$params = $request->getParams();
+	if (isset($params['direct'])) {
+		return;
+	}
+
+	header('Location: '. $masterUrl);
+	exit();
 }


### PR DESCRIPTION
Users should always login at the global site selector. Only exception,
an admin who want to perform some administration tasks. In this case
they can call the login page with the parameter '?direct=1`