### PR TITLE
Add public capability

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -5,7 +5,7 @@
 	<name>Global Site Selector</name>
 	<summary>Nextcloud Portal to redirect users to the right instance</summary>
 	<description>The Global Site Selector allows you to run multiple small Nextcloud instances and redirect users to the right server</description>
-	<version>1.2.0</version>
+	<version>1.2.1</version>
 	<licence>agpl</licence>
 	<author>Bjoern Schiessle</author>
 	<namespace>GlobalSiteSelector</namespace>

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -25,6 +25,7 @@ namespace OCA\GlobalSiteSelector\AppInfo;
 
 use OCA\GlobalSiteSelector\GlobalSiteSelector;
 use OCA\GlobalSiteSelector\Master;
+use OCA\GlobalSiteSelector\PublicCapabilities;
 use OCA\GlobalSiteSelector\Slave;
 use OCA\GlobalSiteSelector\UserBackend;
 use OCP\AppFramework\App;
@@ -47,8 +48,9 @@ class Application extends App {
 		} else {
 			$this->registerSlaveHooks($container);
 			$this->registerUserBackendForSlave($container);
-
 		}
+
+		$container->registerCapability(PublicCapabilities::class);
 	}
 
 	/**

--- a/lib/PublicCapabilities.php
+++ b/lib/PublicCapabilities.php
@@ -1,0 +1,38 @@
+<?php
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2019, Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @author Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\GlobalSiteSelector;
+
+use OCP\Capabilities\IPublicCapability;
+
+class PublicCapabilities implements IPublicCapability {
+	public function getCapabilities(): array {
+		return [
+			'globalscale' => [
+				'enabled' => true,
+				'desktoplogin' => 1,
+			]
+		];
+	}
+}


### PR DESCRIPTION
This allows clients to figure out if they are taking to a GS node or not.
And it signals wich version of  auth the desktop client should use.