### PR TITLE
fix(manual): login fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,6 @@ The additional parameters you need to specify in the config.php are the followin
 
 ````
 'gss.discovery.manual.mapping.file' => '/path/to/file'
-'gss.discovery.manual.mapping.parameter' => 'idp-parameter'
 ````
 
 Optionally the keys in the JSON file can contain regular expressions which will
@@ -103,6 +102,7 @@ be matched against the parameter of the IDP, in this case the following config.p
 parameter has to be set:
 
 ````
+'gss.discovery.manual.mapping.parameter' => 'uid'
 'gss.discovery.manual.mapping.regex' => true
 
 ````

--- a/lib/Lookup.php
+++ b/lib/Lookup.php
@@ -98,8 +98,8 @@ class Lookup {
 			}
 
 		} catch (\Exception $e) {
-			// Nothing to do, we just return a empty string below as a indicator
-			// that nothing was found
+			$emsg = var_export($e, true);
+			$this->logger->debug('exception caught querying lookup server: ' . $emsg);
 		}
 
 		$this->logger->debug('serach: location for ' . $uid . ' is ' . $result);

--- a/lib/Master.php
+++ b/lib/Master.php
@@ -137,10 +137,12 @@ class Master {
 			// we only send the formatted user data to the slave
 			$options['userData'] = $options['userData']['formatted'];
 		} else {
-			$this->logger->debug('handleLoginRequest: backend is not SAML');
+			$this->logger->debug('handleLoginRequest: backend is Manual');
 
 			$uid = $param['uid'];
 			$password = isset($param['password']) ? $param['password'] : '';
+			// quick fix, makes for a limited choice of idpParameter
+			$discoveryData['manual'] = [ "uid" => $uid ];
 		}
 
 		$this->logger->debug('handleLoginRequest: uid is: ' . $uid);

--- a/lib/UserDiscoveryModules/ManualUserMapping.php
+++ b/lib/UserDiscoveryModules/ManualUserMapping.php
@@ -32,10 +32,10 @@ use OCP\ILogger;
  * Therefore you have to define to values in the config.php
  *
  * 'gss.discovery.manual.mapping.file' => '/path/to/json-file'
- * 'gss.discovery.manual.mapping.parameter' => 'idp-parameter'
  *
  * And then there is another optional parameter if you want to use regular expressions:
  *
+ * 'gss.discovery.manual.mapping.parameter' => 'uid'
  * 'gss.discovery.manual.mapping.regex' => true
  *
  * @package OCA\GlobalSiteSelector\UserDiscoveryModules
@@ -57,7 +57,7 @@ class ManualUserMapping implements IUserDiscoveryModule {
 	 * @param IConfig $config
 	 */
 	public function __construct(IConfig $config, ILogger $logger) {
-		$this->idpParameter = $config->getSystemValue('gss.discovery.manual.mapping.parameter', '');
+		$this->idpParameter = $config->getSystemValue('gss.discovery.manual.mapping.parameter', 'uid');
 		$this->file = $config->getSystemValue('gss.discovery.manual.mapping.file', '');
 		$this->useRegularExpressions = $config->getSystemValue('gss.discovery.manual.mapping.regex', false);
 		$this->logger = $logger;
@@ -134,11 +134,13 @@ class ManualUserMapping implements IUserDiscoveryModule {
 	 */
 	private function getKey($data) {
 		$key = '';
-		if (!empty($this->idpParameter) && isset($data['saml'][$this->idpParameter][0])) {
-			$key = $data['saml'][$this->idpParameter][0];
+		if (!empty($this->idpParameter) && isset($data['manual'][$this->idpParameter])) {
+			$key = $data['manual'][$this->idpParameter];
 			$this->logger->debug('Found idpPrameter ' . $this->idpParameter . ' with value "' . $key . '"');
 		} else {
-			$this->logger->debug('Could not find idpParamter: ' . $this->idpParameter);
+			$debugdata = var_export($data['manual'], true);
+			$this->logger->debug('Could not find idpParamter: ' . $this->idpParameter
+					    . ' in user data: ' . $debugdata);
 		}
 
 		return $this->normalizeKey($key);


### PR DESCRIPTION
when using manual user mappings, `lib/Master` does not initializes the `$discoveryData` ultimately sent to `lib/UserDiscoveryModules/ManualUserMapping`, the `getKey` makes checks against an empty array, preventing the dictionary from even being checked.

Also adds a couple debugs, not strictly necessary, open to suggestions

keeping in mind this remains theoric - login still doesn not work. On NC 20, posting login data on the master, the redirection doesn't seem to work. Server is found in JSON file, receives a call from the user logging in (`/index.php/apps/globalsiteselector/autologin?jwt=xxx`), which is replied to with a 303, sending the user back to the login page on the slave NextCloud, which, being a slave, then redirects you back to the login page on the master NextCloud... weird...

Also unclear why do we even have a `gss.discovery.manual.mapping.parameter`. As we're not receiving any metadata from an IDP, all we have at that stage is basically an UID.