### PR TITLE
Fix session token creation "remember" parameter

### DIFF
--- a/lib/Controller/SlaveController.php
+++ b/lib/Controller/SlaveController.php
@@ -25,6 +25,7 @@ namespace OCA\GlobalSiteSelector\Controller;
 
 use Firebase\JWT\ExpiredException;
 use Firebase\JWT\JWT;
+use OC\Authentication\Token\IToken;
 use OCA\GlobalSiteSelector\GlobalSiteSelector;
 use OCA\GlobalSiteSelector\TokenHandler;
 use OCA\GlobalSiteSelector\UserBackend;
@@ -171,7 +172,7 @@ class SlaveController extends OCSController {
 			return new RedirectResponse($masterUrl);
 		}
 
-		$this->userSession->createSessionToken($this->request, $uid, $uid, null, 0);
+		$this->userSession->createSessionToken($this->request, $uid, $uid, null, IToken::REMEMBER);
 		$home = $this->urlGenerator->getAbsoluteURL($target);
 		return new RedirectResponse($home);
 


### PR DESCRIPTION
When the slave controller creates the session token on login, the `remember` parameter is set to `IToken::DO_NOT_REMEMBER`.

This has a visible negative side effect: It is impossible to create an app password (in the web UI) after having logged in via GSS because `OC\User\Session` because `app_password` is set in the session in this case.

https://github.com/nextcloud/server/blob/582234322a59e32fd0d220023a260b66a9b205f2/lib/private/User/Session.php#L850-L854

As it is expected to prevent app password creation when authenticated with an app password, I think it should be possible when logging in via GSS.

I don't know if this is an acceptable fix and if it has bad side effects but it solves the app password generation issue.