### PR TITLE
only send SAML users to SAML logout process

### DIFF
--- a/lib/Controller/MasterController.php
+++ b/lib/Controller/MasterController.php
@@ -29,6 +29,7 @@ use OCP\AppFramework\Http\RedirectResponse;
 use OCP\AppFramework\OCSController;
 use OCP\ILogger;
 use OCP\IRequest;
+use OCP\ISession;
 use OCP\IURLGenerator;
 
 /**
@@ -49,6 +50,9 @@ class MasterController extends OCSController {
 	/** @var ILogger */
 	private $logger;
 
+	/** @var ISession */
+	private $session;
+
 	/**
 	 * SlaveController constructor.
 	 *
@@ -62,12 +66,14 @@ class MasterController extends OCSController {
 								IRequest $request,
 								IURLGenerator $urlGenerator,
 								ILogger $logger,
-								GlobalSiteSelector $globalSiteSelector
+								GlobalSiteSelector $globalSiteSelector,
+								ISession $session
 	) {
 		parent::__construct($appName, $request);
 		$this->urlGenerator = $urlGenerator;
 		$this->logger = $logger;
 		$this->gss = $globalSiteSelector;
+		$this->session = $session;
 	}
 
 	/**
@@ -84,7 +90,7 @@ class MasterController extends OCSController {
 
 			if ($this->isValidJwt($jwt)) {
 				$logoutUrl = $this->urlGenerator->linkToRoute('user_saml.SAML.singleLogoutService');
-				if (!empty($logoutUrl)) {
+				if (!empty($logoutUrl) && $this->session->get('user_saml.Idp') !== null) {
 					$token = ['logout' => 'logout',
 						'exp' => time() + 300, // expires after 5 minutes
 					];


### PR DESCRIPTION
This is the patch from https://github.com/nextcloud-gmbh/customers/issues/757#issuecomment-1234697448 which was tested positively. 

To sum up the background:
1. If a SAML configuration is set, all logouts are send to the SAML endpoint
2. This results in a server error for non-SAML users

For the fix, we need to distinguish whether the target user belongs to an SAML setup, or not. In this patch I relied on presence of `'user_saml.Idp'` in the session. SAML meta data in the session is required for a working SAML logout, therefore it seems to be safe.

Alternatively we might need to get the current logged in user, and check the backend. This would be slightly heavier, but has the advantage to not count on user_saml internals. I suppose that should work, but I am not sure which user state is shared between the nodes and the gss master. If this attempt would be reliable however, I think it would be best, as it solely relies on the user backend. It might also not be reliable, though, when SAML sits in front of other backends (e.g. SAML auth with configured LDAP). Then ^ option would be the approach that really can tell whether a SAML logout is feasible. In that case we can think more of how to better capsulate it and use an API or event over checking user_saml internals.

