### PR TITLE
Add gss.updatels.interval config to tune the interval between lookup-server updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ Config parameters to operate the server in slave mode:
 
 // url of the master, so we can redirect the user back in case of an error
 'gss.master.url' => 'http://localhost/nextcloud2',
+
+// interval (in seconds) between lookup-server updates
+'gss.updatels.interval' => 86400,
 ````
 
 The Slave will always redirect not logged in user to the master to perform the login.

--- a/lib/BackgroundJobs/UpdateLookupServer.php
+++ b/lib/BackgroundJobs/UpdateLookupServer.php
@@ -29,18 +29,20 @@ use OCA\GlobalSiteSelector\Slave;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\IJob;
 use OCP\BackgroundJob\TimedJob;
+use OCP\IConfig;
 
 class UpdateLookupServer extends TimedJob {
 
 
 	public function __construct(
 		ITimeFactory $time,
+		IConfig $config,
 		private GlobalSiteSelector $globalSiteSelector,
 		private Slave $slave
 	) {
 		parent::__construct($time);
 
-		$this->setInterval(86400);
+		$this->setInterval($config->getSystemValueInt('gss.updatels.interval', 86400));
 		$this->setTimeSensitivity(IJob::TIME_SENSITIVE);
 	}
 


### PR DESCRIPTION
This PR allows to configure the interval between successive lookup-server updates, which can be useful for different setups or troubleshootings. The hard-coded value was 86400 (1 day).