### PR TITLE
Add oidc support

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Config.php parameters to operate the server in master mode:
 //       The user disovery module might require additional config paramters you can find in
 //       the documentation of the module
 'gss.user.discovery.module' => '\OCA\GlobalSiteSelector\UserDiscoveryModules\UserDiscoverySAML',
+// or 'gss.user.discovery.module' => '\OCA\GlobalSiteSelector\UserDiscoveryModules\UserDiscoveryOIDC'
 
 // define a allow list for automatic login to other instance to let browsers handle the redirect properly
 'gss.master.csp-allow' => ['*.myorg.com', 'node3.otherorg.com'],
@@ -80,11 +81,21 @@ specific use case:
 
 #### UserDiscoverySAML
 
-This modules reads the location directly from a parameter of the IDP which contain
-the exact URL to the server. The name of the parameter can be defined this way:
+This modules reads the location directly from a parameter of the IDP which contains
+the exact URL to the slave target server. The name of the parameter can be defined this way:
 
 ````
 'gss.discovery.saml.slave.mapping' => 'idp-parameter'
+````
+
+#### UserDiscoveryOIDC
+
+This module is similar to UserDiscoverySAML.
+It reads the location from an OIDC token attribute which contains
+the exact URL to the slave target server. The attribute can be defined this way:
+
+````
+'gss.discovery.oidc.slave.mapping' => 'token-attribute'
 ````
 
 #### ManualUserMapping

--- a/lib/Controller/MasterController.php
+++ b/lib/Controller/MasterController.php
@@ -67,13 +67,22 @@ class MasterController extends OCSController {
 			if ($jwt !== null) {
 				$key = $this->gss->getJwtKey();
 				$decoded = (array)JWT::decode($jwt, new Key($key, Application::JWT_ALGORITHM));
-				$idp = $decoded['saml.idp'] ?? null;
 
-				$logoutUrl = $this->urlGenerator->linkToRoute('user_saml.SAML.singleLogoutService');
+				// saml idp ID
+				$samlIdp = $decoded['saml.idp'] ?? null;
+				// oidc provider ID
+				$oidcProviderId = $decoded['oidc.providerId'] ?? '';
+
+				if (class_exists('\OCA\User_SAML\UserBackend')) {
+					$logoutUrl = $this->urlGenerator->linkToRoute('user_saml.SAML.singleLogoutService');
+				} elseif (class_exists('\OCA\UserOIDC\User\Backend')) {
+					$logoutUrl = $this->urlGenerator->linkToRoute('user_oidc.login.singleLogoutService');
+				}
 				if (!empty($logoutUrl)) {
 					$token = [
 						'logout' => 'logout',
-						'idp' => $idp,
+						'idp' => $samlIdp,
+						'oidcProviderId' => $oidcProviderId,
 						'exp' => time() + 300, // expires after 5 minutes
 					];
 

--- a/lib/Controller/SlaveController.php
+++ b/lib/Controller/SlaveController.php
@@ -90,8 +90,9 @@ class SlaveController extends OCSController {
 			$this->logger->debug('uid: ' . $uid . ', options: ' . json_encode($options));
 
 			$target = $options['target'];
-			if (($options['backend'] ?? '') === 'saml') {
-				$this->logger->debug('saml enabled');
+			$backend = $options['backend'] ?? '';
+			if ($backend === 'saml' || $backend === 'oidc') {
+				$this->logger->debug('saml or oidc enabled: ' . $backend);
 				$this->autoprovisionIfNeeded($uid, $options);
 
 				$user = $this->userManager->get($uid);
@@ -107,6 +108,12 @@ class SlaveController extends OCSController {
 					Application::APP_ID,
 					Slave::SAML_IDP,
 					$options['saml']['idp'] ?? null
+				);
+				$this->config->setUserValue(
+					$user->getUID(),
+					Application::APP_ID,
+					Slave::OIDC_PROVIDER_ID,
+					$options['oidc']['providerId'] ?? ''
 				);
 
 				$result = true;

--- a/lib/Controller/SlaveController.php
+++ b/lib/Controller/SlaveController.php
@@ -107,7 +107,7 @@ class SlaveController extends OCSController {
 					$user->getUID(),
 					Application::APP_ID,
 					Slave::SAML_IDP,
-					$options['saml']['idp'] ?? null
+					$options['saml']['idp'] ?? ''
 				);
 				$this->config->setUserValue(
 					$user->getUID(),

--- a/lib/Slave.php
+++ b/lib/Slave.php
@@ -19,6 +19,7 @@ use Psr\Log\LoggerInterface;
 
 class Slave {
 	public const SAML_IDP = 'saml_idp';
+	public const OIDC_PROVIDER_ID = 'oidc_provider_id';
 
 	private IUserManager $userManager;
 	private IClientService $clientService;
@@ -279,6 +280,11 @@ class Slave {
 				$user->getUID(),
 				Application::APP_ID,
 				self::SAML_IDP,
+				null),
+			'oidc.providerId' => $this->config->getUserValue(
+				$user->getUID(),
+				Application::APP_ID,
+				self::OIDC_PROVIDER_ID,
 				null),
 			'exp' => time() + 300 // expires after 5 minute
 		];

--- a/lib/UserDiscoveryModules/ManualUserMapping.php
+++ b/lib/UserDiscoveryModules/ManualUserMapping.php
@@ -56,8 +56,8 @@ class ManualUserMapping implements IUserDiscoveryModule {
 	public function getLocation(array $data): string {
 		$location = '';
 		$dictionary = $this->getDictionary();
-		$key = $this->getKey($data);
 
+		$key = $this->getKey($data['saml'] ?? $data['oidc']);
 		$this->logger->debug('Lookup key is: "' . $key . '"');
 
 		// regular lookup
@@ -112,8 +112,12 @@ class ManualUserMapping implements IUserDiscoveryModule {
 	 */
 	private function getKey($data) {
 		$key = '';
-		if (!empty($this->idpParameter) && isset($data['saml'][$this->idpParameter][0])) {
-			$key = $data['saml'][$this->idpParameter][0];
+		if (!empty($this->idpParameter) && array_key_exists($this->idpParameter, $data)) {
+			$keys = $data[$this->idpParameter];
+			if (!is_array($keys)) {
+				$keys = [$keys];
+			}
+			$key = $keys[0];
 			$this->logger->debug('Found idpPrameter ' . $this->idpParameter . ' with value "' . $key . '"');
 		} else {
 			$this->logger->debug('Could not find idpParamter: ' . $this->idpParameter);

--- a/lib/UserDiscoveryModules/UserDiscoveryOIDC.php
+++ b/lib/UserDiscoveryModules/UserDiscoveryOIDC.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\GlobalSiteSelector\UserDiscoveryModules;
+
+use OCP\IConfig;
+
+/**
+ * Class UserDiscoveryOIDC
+ *
+ * Discover initial user location with a dedicated OIDC attribute
+ *
+ * Therefore you have to define two values in the config.php file:
+ *
+ * 'gss.discovery.oidc.slave.mapping' => 'token-attribute'
+ * 'gss.user.discovery.module' => '\OCA\GlobalSiteSelector\UserDiscoveryModules\UserDiscoveryOIDC'
+ *
+ * @package OCA\GlobalSiteSelector\UserDiscoveryModule
+ */
+class UserDiscoveryOIDC implements IUserDiscoveryModule {
+	private string $tokenLocationAttribute;
+
+	public function __construct(IConfig $config) {
+		$this->tokenLocationAttribute = $config->getSystemValueString('gss.discovery.oidc.slave.mapping', '');
+	}
+
+
+	/**
+	 * read user location from OIDC token attribute
+	 *
+	 * @param array $data OIDC attributes to read the location from
+	 *
+	 * @return string
+	 */
+	public function getLocation(array $data): string {
+		$location = '';
+		if (!empty($this->tokenLocationAttribute) && isset($data['oidc'][$this->tokenLocationAttribute])) {
+			$location = $data['oidc'][$this->tokenLocationAttribute];
+		}
+
+		return $location;
+	}
+}


### PR DESCRIPTION
This adds support for user_oidc in the GSS master node.
This requires https://github.com/nextcloud/user_oidc/pull/1011

* Add a `UserDiscoveryOIDC` class to get the user location from an OIDC token attribute
* Update README
* Adjust `MasterController::autoLogout` to redirect to the user_oidc singleLogout URL if needed and pass the provider ID in the JWT logout token
* Adjust `Master::handleLoginRequest` to get the user information and location from user_oidc during login
* Adjust `SlaveController::autoLogin` to parse OIDC information in the GSS login JWT token
* Adjust `Slave::handleLogoutRequest` to insert the OIDC provider ID in the GSS logout JWT token