### PR TITLE
2.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 2.6.0
+
+- support for OIDC (using app user_oidc v6.2.1 or superior)
+- new user discovery mapping 'RemoteUserDiscovery' to obtain instance from external service
+- new config 'gss.updatels.interval' to change update internal to lookup server
+- upgrade composer and clean code
+- compat nc31
+
 ## 2.5.2
 
 - get rid of getEventDispatcher()

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -8,7 +8,7 @@
 	<name>Global Site Selector</name>
 	<summary>Nextcloud Portal to redirect users to the right instance</summary>
 	<description>The Global Site Selector allows you to run multiple small Nextcloud instances and redirect users to the right server</description>
-	<version>2.6.0-dev.0</version>
+	<version>2.6.0</version>
 	<licence>agpl</licence>
 	<author>Bjoern Schiessle</author>
 	<author>Maxence Lange</author>


### PR DESCRIPTION
- support for OIDC (using app user_oidc v6.2.1 or superior)
- new user discovery mapping 'RemoteUserDiscovery' to obtain instance from external service
- new config 'gss.updatels.interval' to change update internal to lookup server
- upgrade composer and clean code
- compat nc31