### PR TITLE
fix: Validate JWT key length for HS256 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,11 @@ To use the Global Site Connector you need to add some config parameters to the c
 Config.php parameters to operate the server in master mode:
 
 ````
-// can be chosen freely, you just have to make sure the master and
-// all slaves have the same key.  Also make sure to choose a strong shared secret.
-'gss.jwt.key' => 'random-key',
+// Shared secret used to sign JWT tokens between master and slave nodes.
+// IMPORTANT: Must be at least 32 characters long (required by HS256 per RFC 7518).
+// Must be identical on master and all slave nodes.
+// Example: use `openssl rand -base64 32` to generate a strong key.
+'gss.jwt.key' => 'random-key-at-least-32-characters',
 
 // operation mode
 'gss.mode' => 'master',
@@ -50,9 +52,10 @@ Config.php parameters to operate the server in master mode:
 Config parameters to operate the server in slave mode:
 
 ````
-// can be chosen freely, you just have to make sure the master and
-// all slaves have the same key. Also make sure to choose a strong shared secret.
-'gss.jwt.key' => 'random-key',
+// Shared secret used to sign JWT tokens between master and slave nodes.
+// IMPORTANT: Must be at least 32 characters long (required by HS256 per RFC 7518).
+// Must be identical on master and all slave nodes.
+'gss.jwt.key' => 'random-key-at-least-32-characters',
 
 // operation mode
 'gss.mode' => 'slave',

--- a/lib/GlobalSiteSelector.php
+++ b/lib/GlobalSiteSelector.php
@@ -23,15 +23,11 @@ class GlobalSiteSelector {
 	public const MASTER = 'master';
 	public const SLAVE = 'slave';
 
-	/** @var IConfig */
-	private $config;
+	public const MIN_JWT_KEY_LENGTH = 32;
 
-	/**
-	 * GlobalSiteSelector constructor.
-	 *
-	 * @param IConfig $config
-	 */
-	public function __construct(IConfig $config) {
+	public function __construct(
+		private IConfig $config,
+	) {
 		$this->config = $config;
 	}
 
@@ -64,8 +60,16 @@ class GlobalSiteSelector {
 	 * @return string
 	 */
 	public function getJwtKey(): string {
-		// TODO: returns exception if non-existant
 		return $this->config->getSystemValueString('gss.jwt.key', '');
+	}
+
+	/**
+	 * Validate that the JWT key meets minimum length requirements.
+	 * HS256 requires a key of at least 256 bits (32 bytes) per RFC 7518 §3.2.
+	 */
+	public function isJwtKeyValid(): bool {
+		$key = $this->getJwtKey();
+		return $key !== '' && strlen($key) >= self::MIN_JWT_KEY_LENGTH;
 	}
 
 	/**

--- a/lib/Master.php
+++ b/lib/Master.php
@@ -310,6 +310,16 @@ class Master {
 	 * @return string
 	 */
 	protected function createJwt($uid, $password, $options) {
+		if (!$this->gss->isJwtKeyValid()) {
+			$this->logger->error(
+				'gss.jwt.key is too short: HS256 requires at least '
+				. GlobalSiteSelector::MIN_JWT_KEY_LENGTH . ' characters (per RFC 7518). '
+				. 'Current key length: ' . strlen($this->gss->getJwtKey()) . '. '
+				. 'Please update gss.jwt.key in config.php on all nodes.',
+				['app' => Application::APP_ID]
+			);
+		}
+
 		$token = [
 			'uid' => $uid,
 			'password' => $this->crypto->encrypt($password, $this->gss->getJwtKey()),

--- a/lib/Slave.php
+++ b/lib/Slave.php
@@ -257,6 +257,16 @@ class Slave {
 			return false;
 		}
 
+		if (!$this->gss->isJwtKeyValid()) {
+			$this->logger->error(
+				'gss.jwt.key is too short: HS256 requires at least '
+				. GlobalSiteSelector::MIN_JWT_KEY_LENGTH . ' characters (per RFC 7518). '
+				. 'Current key length: ' . strlen($this->authKey) . '. '
+				. 'Please update gss.jwt.key in config.php on all nodes.',
+				['app' => Application::APP_ID]
+			);
+		}
+
 		return true;
 	}
 

--- a/tests/unit/lib/GlobalSiteSelectorTest.php
+++ b/tests/unit/lib/GlobalSiteSelectorTest.php
@@ -60,4 +60,25 @@ class GlobalSiteSelectorTest extends TestCase {
 
 		$this->assertSame('result', $result);
 	}
+
+	public function testIsJwtKeyValidWithShortKey() {
+		$this->config->method('getSystemValueString')
+			->with('gss.jwt.key', '')->willReturn('short-key');
+
+		$this->assertFalse($this->gss->isJwtKeyValid());
+	}
+
+	public function testIsJwtKeyValidWithEmptyKey() {
+		$this->config->method('getSystemValueString')
+			->with('gss.jwt.key', '')->willReturn('');
+
+		$this->assertFalse($this->gss->isJwtKeyValid());
+	}
+
+	public function testIsJwtKeyValidWithValidKey() {
+		$this->config->method('getSystemValueString')
+			->with('gss.jwt.key', '')->willReturn('this-key-is-at-least-32-characters-long!');
+
+		$this->assertTrue($this->gss->isJwtKeyValid());
+	}
 }


### PR DESCRIPTION
The HS256 algorithm requires a minimum key of 32 bytes per RFC 7518. firebase/php-jwt v7 (used by user_oidc) enforces this, while v6 (used by GSS) does not, causing silent JWT decode failures during OIDC logout delegation from slave to master.

Added key length validation with clear error logging in both Master and Slave, and updated README to document the requirement.