### PR TITLE
setup check on jwt key length

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -20,6 +20,7 @@ use OCA\GlobalSiteSelector\Listeners\UserDeleted;
 use OCA\GlobalSiteSelector\Listeners\UserLoggedOut;
 use OCA\GlobalSiteSelector\Listeners\UserLoggingIn;
 use OCA\GlobalSiteSelector\PublicCapabilities;
+use OCA\GlobalSiteSelector\SetupChecks\LongJwtKeySetupCheck;
 use OCA\GlobalSiteSelector\Slave;
 use OCA\GlobalSiteSelector\UserBackend;
 use OCP\AppFramework\App;
@@ -79,6 +80,8 @@ class Application extends App implements IBootstrap {
 		$context->registerEventListener(BeforeUserDeletedEvent::class, DeletingUser::class);
 		$context->registerEventListener(UserDeletedEvent::class, UserDeleted::class);
 		$context->registerEventListener(UserLoggedOutEvent::class, UserLoggedOut::class);
+
+		$context->registerSetupCheck(LongJwtKeySetupCheck::class);
 
 		// It seems that AccountManager use deprecated dispatcher, let's use a deprecated listener
 		/** @var IEventDispatcher $eventDispatcher */

--- a/lib/SetupChecks/LongJwtKeySetupCheck.php
+++ b/lib/SetupChecks/LongJwtKeySetupCheck.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\GlobalSiteSelector\SetupChecks;
+
+use OCA\GlobalSiteSelector\GlobalSiteSelector;
+use OCP\SetupCheck\ISetupCheck;
+use OCP\SetupCheck\SetupResult;
+
+class LongJwtKeySetupCheck implements ISetupCheck {
+	public function __construct(
+		private readonly GlobalSiteSelector $gss,
+	) {
+	}
+
+	public function getName(): string {
+		return 'Globalscale Jwt key';
+	}
+
+	public function getCategory(): string {
+		return 'globalscale';
+	}
+
+	public function run(): SetupResult {
+		if (strlen($this->gss->getJwtKey()) > 31) {
+			return SetupResult::success('gss.jwt.key is set to a long enough string');
+		}
+
+		return SetupResult::error(
+			'Current value for \'gss.jwt.key\' in `config.php` is too short, which will be a blocker in Nextcloud 34. '
+			. 'Please set a new key longer than 31 chars. '
+			. 'Warning: This key being shared between the Lookup Server and all instances of the Globalscale - portal and nodes - it needs to be modified at all location simultaneously');
+	}
+}


### PR DESCRIPTION
in NC34 we will enforce a minimum length of 32 chargs for jwt key with #188; this will notify admin on 32, 33