### PR TITLE
fix(slave-controller): add rate limit protection

### DIFF
--- a/lib/Controller/SlaveController.php
+++ b/lib/Controller/SlaveController.php
@@ -25,9 +25,11 @@ use OCA\GlobalSiteSelector\Vendor\Firebase\JWT\ExpiredException;
 use OCA\GlobalSiteSelector\Vendor\Firebase\JWT\JWT;
 use OCA\GlobalSiteSelector\Vendor\Firebase\JWT\Key;
 use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\BruteForceProtection;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\Attribute\PublicPage;
+use OCP\AppFramework\Http\Attribute\UseSession;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\Http\RedirectResponse;
 use OCP\AppFramework\OCSController;
@@ -122,15 +124,10 @@ class SlaveController extends OCSController {
 	}
 
 
-	/**
-	 * @PublicPage
-	 * @NoCSRFRequired
-	 * @UseSession
-	 *
-	 * @param string $jwt
-	 *
-	 * @return RedirectResponse
-	 */
+	#[PublicPage]
+	#[NoCSRFRequired]
+	#[UseSession]
+	#[BruteForceProtection(action: 'autoLogin')]
 	public function autoLogin(string $jwt): RedirectResponse {
 		$this->logger->debug('autologin incoming request with ' . $jwt);
 
@@ -141,11 +138,10 @@ class SlaveController extends OCSController {
 			return new RedirectResponse('');
 		}
 
-		if ($this->gss->isMaster()) {
-			return new RedirectResponse($masterUrl);
-		}
-		if ($jwt === '') {
-			return new RedirectResponse($masterUrl);
+		if ($this->gss->isMaster() || $jwt === '') {
+			$response = new RedirectResponse($masterUrl);
+			$response->throttle();
+			return $response;
 		}
 
 		try {
@@ -192,12 +188,14 @@ class SlaveController extends OCSController {
 			}
 		} catch (ExpiredException $e) {
 			$this->logger->info('token expired');
-
-			return new RedirectResponse($masterUrl);
+			$response = new RedirectResponse($masterUrl);
+			$response->throttle();
+			return $response;
 		} catch (\Exception $e) {
 			$this->logger->warning('issue during login process', ['exception' => $e]);
-
-			return new RedirectResponse($masterUrl);
+			$response = new RedirectResponse($masterUrl);
+			$response->throttle();
+			return $response;
 		}
 
 		$this->logger->debug('all good. creating session');
@@ -227,17 +225,14 @@ class SlaveController extends OCSController {
 		return new RedirectResponse($home);
 	}
 
-	/**
-	 * Create app token
-	 *
-	 * @PublicPage
-	 * @NoAdminRequired
-	 *
-	 * @return DataResponse
-	 */
-	public function createAppToken($jwt) {
+	#[PublicPage]
+	#[NoAdminRequired]
+	#[BruteForceProtection(action: 'createAppToken')]
+	public function createAppToken($jwt): DataResponse {
 		if ($this->gss->getMode() === 'master' || empty($jwt)) {
-			return new DataResponse([], Http::STATUS_BAD_REQUEST);
+			$response = new DataResponse([], Http::STATUS_BAD_REQUEST);
+			$response->throttle();
+			return $response;
 		}
 
 		try {
@@ -262,7 +257,9 @@ class SlaveController extends OCSController {
 			$this->logger->info('issue while token creation', ['exception' => $e]);
 		}
 
-		return new DataResponse([], Http::STATUS_BAD_REQUEST);
+		$response = new DataResponse([], Http::STATUS_BAD_REQUEST);
+		$response->throttle();
+		return $response;
 	}
 
 	/**


### PR DESCRIPTION
* Resolves: #

## Summary

- adds BruteForceProtection on SlaveController::autoLogin()

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
