### PR TITLE
feat: add missing stubs to fix psalm errors

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -26,6 +26,8 @@
 		<file name="tests/stubs/oc_appframework_ocs_v1response.php" />
 		<file name="tests/stubs/oc_appframework_utility_simplecontainer.php" />
 		<file name="tests/stubs/oc_core_command_base.php" />
+		<file name="tests/stubs/oc_core_controller_clientflowloginv2controller.php" />
+		<file name="tests/stubs/oc_core_service_loginflowv2service.php" />
 		<file name="tests/stubs/oc_files_cache_cache.php" />
 		<file name="tests/stubs/oc_files_cache_cacheentry.php" />
 		<file name="tests/stubs/oc_files_cache_scanner.php" />

--- a/tests/stubs/oc_core_controller_clientflowloginv2controller.php
+++ b/tests/stubs/oc_core_controller_clientflowloginv2controller.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OC\Core\Controller;
+
+use OC\Core\Db\LoginFlowV2;
+use OC\Core\Exception\LoginFlowV2ClientForbiddenException;
+use OC\Core\Exception\LoginFlowV2NotFoundException;
+use OC\Core\ResponseDefinitions;
+use OC\Core\Service\LoginFlowV2Service;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\FrontpageRoute;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
+use OCP\AppFramework\Http\Attribute\NoSameSiteCookieRequired;
+use OCP\AppFramework\Http\Attribute\OpenAPI;
+use OCP\AppFramework\Http\Attribute\PasswordConfirmationRequired;
+use OCP\AppFramework\Http\Attribute\PublicPage;
+use OCP\AppFramework\Http\Attribute\UseSession;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\AppFramework\Http\RedirectResponse;
+use OCP\AppFramework\Http\Response;
+use OCP\AppFramework\Http\StandaloneTemplateResponse;
+use OCP\AppFramework\Services\IInitialState;
+use OCP\Authentication\Exceptions\InvalidTokenException;
+use OCP\Defaults;
+use OCP\IL10N;
+use OCP\IRequest;
+use OCP\ISession;
+use OCP\IURLGenerator;
+use OCP\IUserSession;
+use OCP\Security\ISecureRandom;
+use OCP\Server;
+use OCP\Util;
+
+/**
+ * @psalm-import-type CoreLoginFlowV2Credentials from ResponseDefinitions
+ * @psalm-import-type CoreLoginFlowV2 from ResponseDefinitions
+ */
+class ClientFlowLoginV2Controller extends Controller {
+	public const TOKEN_NAME = 'client.flow.v2.login.token';
+	public const STATE_NAME = 'client.flow.v2.state.token';
+
+	public function __construct(string $appName, IRequest $request, private LoginFlowV2Service $loginFlowV2Service, private IURLGenerator $urlGenerator, private ISession $session, private IUserSession $userSession, private ISecureRandom $random, private Defaults $defaults, private ?string $userId, private IL10N $l10n, private IInitialState $initialState)
+    {
+    }
+
+	/**
+	 * Poll the login flow credentials
+	 *
+	 * @param string $token Token of the flow
+	 * @return JSONResponse<Http::STATUS_OK, CoreLoginFlowV2Credentials, array{}>|JSONResponse<Http::STATUS_NOT_FOUND, list<empty>, array{}>
+	 *
+	 * 200: Login flow credentials returned
+	 * 404: Login flow not found or completed
+	 */
+	#[NoCSRFRequired]
+    #[PublicPage]
+    #[FrontpageRoute(verb: 'POST', url: '/login/v2/poll')]
+    #[OpenAPI(scope: OpenAPI::SCOPE_DEFAULT)]
+    public function poll(string $token): JSONResponse
+    {
+    }
+
+	#[NoCSRFRequired]
+    #[PublicPage]
+    #[OpenAPI(scope: OpenAPI::SCOPE_IGNORE)]
+    #[UseSession]
+    #[FrontpageRoute(verb: 'GET', url: '/login/v2/flow/{token}')]
+    public function landing(string $token, $user = '', int $direct = 0): Response
+    {
+    }
+
+	#[NoCSRFRequired]
+    #[PublicPage]
+    #[OpenAPI(scope: OpenAPI::SCOPE_IGNORE)]
+    #[UseSession]
+    #[FrontpageRoute(verb: 'GET', url: '/login/v2/flow')]
+    public function showAuthPickerPage(string $user = '', int $direct = 0): StandaloneTemplateResponse
+    {
+    }
+
+	#[NoAdminRequired]
+    #[NoCSRFRequired]
+    #[OpenAPI(scope: OpenAPI::SCOPE_IGNORE)]
+    #[UseSession]
+    #[FrontpageRoute(verb: 'GET', url: '/login/v2/grant')]
+    #[NoSameSiteCookieRequired]
+    public function grantPage(?string $stateToken, int $direct = 0): StandaloneTemplateResponse
+    {
+    }
+
+	#[PublicPage]
+    #[FrontpageRoute(verb: 'POST', url: '/login/v2/apptoken')]
+    public function apptokenRedirect(?string $stateToken, string $user, string $password)
+    {
+    }
+
+	#[NoAdminRequired]
+    #[UseSession]
+    #[PasswordConfirmationRequired(strict: false)]
+    #[FrontpageRoute(verb: 'POST', url: '/login/v2/grant')]
+    public function generateAppPassword(?string $stateToken): Response
+    {
+    }
+
+	/**
+	 * Init a login flow
+	 *
+	 * @return JSONResponse<Http::STATUS_OK, CoreLoginFlowV2, array{}>
+	 *
+	 * 200: Login flow init returned
+	 */
+	#[NoCSRFRequired]
+    #[PublicPage]
+    #[FrontpageRoute(verb: 'POST', url: '/login/v2')]
+    #[OpenAPI(scope: OpenAPI::SCOPE_DEFAULT)]
+    public function init(): JSONResponse
+    {
+    }
+}

--- a/tests/stubs/oc_core_service_loginflowv2service.php
+++ b/tests/stubs/oc_core_service_loginflowv2service.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OC\Core\Service;
+
+use OC\Authentication\Exceptions\PasswordlessTokenException;
+use OC\Authentication\Token\IProvider;
+use OC\Authentication\Token\IToken;
+use OC\Core\Data\LoginFlowV2Credentials;
+use OC\Core\Data\LoginFlowV2Tokens;
+use OC\Core\Db\LoginFlowV2;
+use OC\Core\Db\LoginFlowV2Mapper;
+use OC\Core\Exception\LoginFlowV2ClientForbiddenException;
+use OC\Core\Exception\LoginFlowV2NotFoundException;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\Authentication\Exceptions\InvalidTokenException;
+use OCP\IConfig;
+use OCP\Security\ICrypto;
+use OCP\Security\ISecureRandom;
+use Psr\Log\LoggerInterface;
+
+class LoginFlowV2Service {
+	public function __construct(
+		private LoginFlowV2Mapper $mapper,
+		private ISecureRandom $random,
+		private ITimeFactory $time,
+		private IConfig $config,
+		private ICrypto $crypto,
+		private LoggerInterface $logger,
+		private IProvider $tokenProvider,
+	) {
+	}
+
+	/**
+	 * @param string $pollToken
+	 * @return LoginFlowV2Credentials
+	 * @throws LoginFlowV2NotFoundException
+	 */
+	public function poll(string $pollToken): LoginFlowV2Credentials
+    {
+    }
+
+	/**
+	 * @param string $loginToken
+	 * @return LoginFlowV2
+	 * @throws LoginFlowV2NotFoundException
+	 * @throws LoginFlowV2ClientForbiddenException
+	 */
+	public function getByLoginToken(string $loginToken): LoginFlowV2
+    {
+    }
+
+	/**
+	 * @param string $loginToken
+	 * @return bool returns true if the start was successfull. False if not.
+	 */
+	public function startLoginFlow(string $loginToken): bool
+    {
+    }
+
+	/**
+	 * @param string $loginToken
+	 * @param string $sessionId
+	 * @param string $server
+	 * @param string $userId
+	 * @return bool true if the flow was successfully completed false otherwise
+	 */
+	public function flowDone(string $loginToken, string $sessionId, string $server, string $userId): bool
+    {
+    }
+
+	public function flowDoneWithAppPassword(string $loginToken, string $server, string $loginName, string $appPassword): bool
+    {
+    }
+
+	public function createTokens(string $userAgent): LoginFlowV2Tokens
+    {
+    }
+}


### PR DESCRIPTION
* Resolves: #

## Summary

- depends on https://github.com/nextcloud/globalsiteselector/pull/198 being merged first
- adds missing stubs to solve the following psalm errors:
```bash
Error: lib/Master.php:46:3: UndefinedClass: Class, interface or enum named OC\Core\Service\LoginFlowV2Service does not exist (see https://psalm.dev/019)
Error: lib/Master.php:280:40: UndefinedClass: Class, interface or enum named OC\Core\Controller\ClientFlowLoginV2Controller does not exist (see https://psalm.dev/019)
Error: lib/Master.php:282:15: UndefinedClass: Class, interface or enum named OC\Core\Service\LoginFlowV2Service does not exist (see https://psalm.dev/019)
```
- stubs were added using https://codeberg.org/provokateurin/php-stubs-updater/

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI