### PR TITLE
fix: propagate disabled state to lookup server

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -15,6 +15,7 @@ use OC;
 use OCA\GlobalSiteSelector\GlobalSiteSelector;
 use OCA\GlobalSiteSelector\Listeners\AddContentSecurityPolicyListener;
 use OCA\GlobalSiteSelector\Listeners\DeletingUser;
+use OCA\GlobalSiteSelector\Listeners\UserChanged;
 use OCA\GlobalSiteSelector\Listeners\UserCreated;
 use OCA\GlobalSiteSelector\Listeners\UserDeleted;
 use OCA\GlobalSiteSelector\Listeners\UserLoggedOut;
@@ -36,6 +37,7 @@ use OCP\Security\CSP\AddContentSecurityPolicyEvent;
 use OCP\Server;
 use OCP\User\Events\BeforeUserDeletedEvent;
 use OCP\User\Events\BeforeUserLoggedInEvent;
+use OCP\User\Events\UserChangedEvent;
 use OCP\User\Events\UserCreatedEvent;
 use OCP\User\Events\UserDeletedEvent;
 use OCP\User\Events\UserLoggedOutEvent;
@@ -80,6 +82,7 @@ class Application extends App implements IBootstrap {
 		$context->registerEventListener(BeforeUserDeletedEvent::class, DeletingUser::class);
 		$context->registerEventListener(UserDeletedEvent::class, UserDeleted::class);
 		$context->registerEventListener(UserLoggedOutEvent::class, UserLoggedOut::class);
+		$context->registerEventListener(UserChangedEvent::class, UserChanged::class);
 
 		$context->registerSetupCheck(LongJwtKeySetupCheck::class);
 

--- a/lib/Controller/SlaveController.php
+++ b/lib/Controller/SlaveController.php
@@ -9,6 +9,7 @@
 namespace OCA\GlobalSiteSelector\Controller;
 
 use OC\Authentication\Token\IProvider;
+use OC\User\DisabledUserException;
 use OCA\GlobalSiteSelector\AppInfo\Application;
 use OCA\GlobalSiteSelector\Exceptions\LocalFederatedShareException;
 use OCA\GlobalSiteSelector\Exceptions\MasterUrlException;
@@ -63,6 +64,7 @@ class SlaveController extends OCSController {
 		private readonly IUserManager $userManager,
 		private readonly UserBackend $userBackend,
 		private readonly ISession $session,
+		private readonly Slave $slave,
 		private readonly SlaveService $slaveService,
 		private readonly GlobalScaleService $globalScaleService,
 		private readonly GlobalShareService $globalShareService,
@@ -159,6 +161,9 @@ class SlaveController extends OCSController {
 				if (!($user instanceof IUser)) {
 					throw new \InvalidArgumentException('User is not valid');
 				}
+				if (!$user->isEnabled()) {
+					throw new DisabledUserException('Account disabled');
+				}
 				$user->updateLastLoginTimestamp();
 
 				$this->session->set('globalScale.userData', $options);
@@ -191,6 +196,12 @@ class SlaveController extends OCSController {
 			$response = new RedirectResponse($masterUrl);
 			$response->throttle();
 			return $response;
+		} catch (DisabledUserException $e) {
+			// user is disabled, remove from lookup server
+			$params = ['uid' => $uid];
+			$this->slave->preDeleteUser($params);
+			$this->slave->deleteUser($params);
+			return new RedirectResponse($masterUrl);
 		} catch (\Exception $e) {
 			$this->logger->warning('issue during login process', ['exception' => $e]);
 			$response = new RedirectResponse($masterUrl);

--- a/lib/Listeners/UserChanged.php
+++ b/lib/Listeners/UserChanged.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\GlobalSiteSelector\Listeners;
+
+use OCA\GlobalSiteSelector\GlobalSiteSelector;
+use OCA\GlobalSiteSelector\Slave;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+use OCP\User\Events\UserChangedEvent;
+
+/**
+ * @template-implements IEventListener<UserChangedEvent>
+ */
+class UserChanged implements IEventListener {
+
+	public function __construct(
+		private GlobalSiteSelector $globalSiteSelector,
+		private Slave $slave,
+	) {
+	}
+
+	public function handle(Event $event): void {
+		if (!$event instanceof UserChangedEvent) {
+			return;
+		}
+
+		if (!$this->globalSiteSelector->isSlave()) {
+			return;
+		}
+
+		if ($event->getFeature() !== 'enabled') {
+			return;
+		}
+
+		$params = ['uid' => $event->getUser()->getUID()];
+
+		if ($event->getValue() === false) {
+			// user was disabled, remove from lookup server
+			$this->slave->preDeleteUser($params);
+			$this->slave->deleteUser($params);
+		} else {
+			// user was enabled, add to lookup server
+			$this->slave->createUser($params);
+		}
+	}
+}

--- a/lib/Slave.php
+++ b/lib/Slave.php
@@ -160,11 +160,10 @@ class Slave {
 			$offset = 0;
 			$usersData = [];
 			do {
-
 				$users = $backend->getUsers('', $limit, $offset);
 				foreach ($users as $uid) {
 					$user = $this->userManager->get($uid);
-					if ($user !== null) {
+					if ($user !== null && $user->isEnabled()) {
 						$usersData[$user->getCloudId()] = $this->slaveService->getAccountData($user);
 					}
 				}

--- a/lib/Slave.php
+++ b/lib/Slave.php
@@ -158,17 +158,28 @@ class Slave {
 		foreach ($backends as $backend) {
 			$limit = 200;
 			$offset = 0;
-			$usersData = [];
 			do {
+				$usersToAdd = [];
+				$usersToRemove = [];
 				$users = $backend->getUsers('', $limit, $offset);
 				foreach ($users as $uid) {
 					$user = $this->userManager->get($uid);
-					if ($user !== null && $user->isEnabled()) {
-						$usersData[$user->getCloudId()] = $this->slaveService->getAccountData($user);
+					if ($user === null) {
+						continue;
+					}
+					if ($user->isEnabled()) {
+						$usersToAdd[$user->getCloudId()] = $this->slaveService->getAccountData($user);
+					} else {
+						$usersToRemove[] = $user->getCloudId();
 					}
 				}
 				$offset += $limit;
-				$this->addUsers($usersData);
+				if ($usersToAdd !== []) {
+					$this->addUsers($usersToAdd);
+				}
+				if ($usersToRemove !== []) {
+					$this->removeUsers($usersToRemove);
+				}
 			} while (count($users) >= $limit);
 		}
 	}

--- a/psalm.xml
+++ b/psalm.xml
@@ -58,6 +58,8 @@
 		<file name="tests/stubs/oc_server.php" />
 		<file name="tests/stubs/oc_servercontainer.php" />
 		<file name="tests/stubs/oc_settings_authorizedgroupmapper.php" />
+		<file name="tests/stubs/oc_user_disableduserexception.php" />
+		<file name="tests/stubs/oc_user_loginexception.php" />
 		<file name="tests/stubs/oc_user_user.php" />
 		<file name="tests/stubs/oca_circles_circlesmanager.php" />
 		<file name="tests/stubs/oca_circles_circlesqueryhelper.php" />

--- a/tests/stubs/oc_user_disableduserexception.php
+++ b/tests/stubs/oc_user_disableduserexception.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+namespace OC\User;
+
+class DisabledUserException extends LoginException {
+}

--- a/tests/stubs/oc_user_loginexception.php
+++ b/tests/stubs/oc_user_loginexception.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+namespace OC\User;
+
+class LoginException extends \Exception {
+}

--- a/tests/unit/lib/Controller/SlaveControllerTest.php
+++ b/tests/unit/lib/Controller/SlaveControllerTest.php
@@ -15,6 +15,7 @@ use OCA\GlobalSiteSelector\GlobalSiteSelector;
 use OCA\GlobalSiteSelector\Service\GlobalScaleService;
 use OCA\GlobalSiteSelector\Service\GlobalShareService;
 use OCA\GlobalSiteSelector\Service\SlaveService;
+use OCA\GlobalSiteSelector\Slave;
 use OCA\GlobalSiteSelector\TokenHandler;
 use OCA\GlobalSiteSelector\UserBackend;
 use OCA\GlobalSiteSelector\Vendor\Firebase\JWT\JWT;
@@ -39,6 +40,7 @@ class SlaveControllerTest extends TestCase {
 	private IUserManager $userManager;
 	private UserBackend $userBackend;
 	private ISession $session;
+	private Slave $slave;
 	private GlobalScaleService $globalScaleService;
 	private GlobalShareService $globalShareService;
 	private SlaveService $slaveService;
@@ -61,6 +63,7 @@ class SlaveControllerTest extends TestCase {
 		$this->userBackend = $this->getMockBuilder(UserBackend::class)
 			->disableOriginalConstructor()->getMock();
 		$this->session = $this->createMock(ISession::class);
+		$this->slave = $this->createMock(Slave::class);
 		$this->slaveService = $this->createMock(SlaveService::class);
 		$this->globalScaleService = $this->createMock(GlobalScaleService::class);
 		$this->globalShareService = $this->createMock(GlobalShareService::class);
@@ -86,6 +89,7 @@ class SlaveControllerTest extends TestCase {
 					$this->userManager,
 					$this->userBackend,
 					$this->session,
+					$this->slave,
 					$this->slaveService,
 					$this->globalScaleService,
 					$this->globalShareService,


### PR DESCRIPTION

* Resolves: https://github.com/nextcloud/lookup-server/issues/183

## Summary

Currently, disabled users are kept on the lookup server as if they were enabled.

This PR introduces the following mechanisms to address this:

- `lib/Listeners/UserChanged` listens for enable/disable events
  - when a user is disabled, removes them from the lookup server
  - when a user is re-enabled, adds them back to the lookup server
- `lib/Slave::batchUpdate()` now checks if a user is enabled before registering them on the lookup server
  - this method syncs all known instance users with the lookup server
  - used by `occ globalsiteselector:users:update` and the `BackgroundJobs/UpdateLookupServer` cron job
- `lib/Controller/SlaveController::autoLogin()` was updated to handle disabled users that were already present on the lookup server
  - catches `DisabledUserException` on login and removes the user from the lookup server in that case

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
