### PR TITLE
fix(workflow): adjust branches on sync-workflow-templates.yml

### DIFF
--- a/.github/workflows/sync-workflow-templates.yml
+++ b/.github/workflows/sync-workflow-templates.yml
@@ -26,9 +26,7 @@ jobs:
       matrix:
         branches:
           - ${{ github.event.repository.default_branch }}
-          - 'stable34'
-          - 'stable33'
-          - 'stable32'
+          - 'stable2.7'
 
     name: Update workflows in ${{ matrix.branches }}
 
@@ -43,14 +41,14 @@ jobs:
           require: admin
 
       - name: Checkout workflow repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
           path: source
           repository: nextcloud/.github
 
       - name: Checkout app
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
           path: target

--- a/.github/workflows/sync-workflow-templates.yml.patch
+++ b/.github/workflows/sync-workflow-templates.yml.patch
@@ -1,0 +1,14 @@
+diff --git a/.github/workflows/sync-workflow-templates.yml b/.github/workflows/sync-workflow-templates.yml
+--- a/.github/workflows/sync-workflow-templates.yml
++++ b/.github/workflows/sync-workflow-templates.yml
+@@ -26,9 +26,7 @@ jobs:
+       matrix:
+         branches:
+           - ${{ github.event.repository.default_branch }}
+-          - 'stable34'
+-          - 'stable33'
+-          - 'stable32'
++          - 'stable2.7'
+ 
+     name: Update workflows in ${{ matrix.branches }}
+ 

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -46,3 +46,9 @@ path = ["tests/stubs/icewind_streams_**"]
 precedence = "aggregate"
 SPDX-FileCopyrightText = "none"
 SPDX-License-Identifier = "MIT"
+
+[[annotations]]
+path = ".github/workflows/sync-workflow-templates.yml.patch"
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2026 Nextcloud GmbH and Nextcloud contributors"
+SPDX-License-Identifier = "MIT"


### PR DESCRIPTION

* Follow up of https://github.com/nextcloud/globalsiteselector/pull/198

## Summary

Branches listed on `sync-workflow-templates.yml` do not match actual branches of this repo:
```yml
jobs:
  dispatch:
    runs-on: ubuntu-latest

    strategy:
      fail-fast: false
      matrix:
        branches:
          - ${{ github.event.repository.default_branch }}
          - 'stable34' # does not exist on this repo
          - 'stable33' # does not exist on this repo
          - 'stable32' # does not exist on this repo
```

This PR adds a patch to change for `branches` section to use branches corresponding to the currently supported versions of NC.

Steps done to add a patch to `sync-workflow-templates.yml`:
```bash
# make changes needed on sync-workflow-templates.yml

# create patch file
git diff .github/workflows/sync-workflow-templates.yml > .github/workflows/sync-workflow-templates.yml.patch

# check patch is in good shape
patch -p1 --dry-run < .github/workflows/sync-workflow-templates.yml.patch

# commit both the patch and workflow with changes

# add patch reference on REUSE.toml
```

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
