### PR TITLE
fix: Do not override default HTTP Client options

### DIFF
--- a/lib/Lookup.php
+++ b/lib/Lookup.php
@@ -203,8 +203,6 @@ class Lookup {
 			[
 				'timeout' => 10,
 				'connect_timeout' => 3,
-				'nextcloud' => ['allow_local_address' => true],
-				'verify' => !$this->config->getSystemValueBool('gss.selfsigned.allow', false),
 			]
 		);
 	}


### PR DESCRIPTION
Currently, we override two options:
1. `verify`, which prevent using custom CA certificates
2. `allow_local_address`, which do not respect the instance wide setting



## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
