### PR TITLE
release 2.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 2.8.0
+
+- feat: IGlobalScaleService
+- feat: enforce long JWT key
+- fix: removing default HTTP Client options override
+
 ## 2.7.3
 
 - fix: add brute force protection and avoid saving token on debug log

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ build_dir=$(CURDIR)/build/artifacts
 source_dir=$(build_dir)/source
 sign_dir=$(build_dir)/sign
 package_name=$(app_name)
-version+=2.7.3
+version+=2.8.0
 
 all: appstore
 

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -8,7 +8,7 @@
 	<name>Global Site Selector</name>
 	<summary>Nextcloud Portal to redirect users to the right instance</summary>
 	<description>The Global Site Selector allows you to run multiple small Nextcloud instances and redirect users to the right server</description>
-	<version>2.7.3</version>
+	<version>2.8.0</version>
 	<licence>agpl</licence>
 	<author>Bjoern Schiessle</author>
 	<author>Maxence Lange</author>
@@ -21,7 +21,7 @@
 	<bugs>https://github.com/nextcloud/globalsiteselector/issues</bugs>
 	<repository>https://github.com/nextcloud/globalsiteselector</repository>
 	<dependencies>
-		<nextcloud min-version="32" max-version="34"/>
+		<nextcloud min-version="33" max-version="35"/>
 	</dependencies>
 	<background-jobs>
 		<job>OCA\GlobalSiteSelector\BackgroundJobs\UpdateLookupServer</job>


### PR DESCRIPTION
while this is set as compatible to 33, it should not be officially distributed with NC lower than 34 as it contains a major change to the JWT key.

_Note: NC33 admin can manually upgrade themself to 2.8.0 if they changes their JWT key_

- [ ] require https://github.com/nextcloud/globalsiteselector/pull/235