### PR TITLE
fix(refactor): allow logout

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -11,6 +11,7 @@ namespace OCA\GlobalSiteSelector\AppInfo;
 
 use Exception;
 use OC;
+use OCA\GlobalSiteSelector\ConfigLexicon;
 use OCA\GlobalSiteSelector\GlobalSiteSelector;
 use OCA\GlobalSiteSelector\Listeners\AddContentSecurityPolicyListener;
 use OCA\GlobalSiteSelector\Listeners\DeletingUser;
@@ -83,6 +84,7 @@ class Application extends App implements IBootstrap {
 		$context->registerEventListener(UserUpdatedEvent::class, UserChanged::class);
 
 		$context->registerSetupCheck(LongJwtKeySetupCheck::class);
+		$context->registerConfigLexicon(ConfigLexicon::class);
 
 		// registerGlobalScaleService() and IGlobalScaleService only exist since Nextcloud
 		// 34.0.3, but this app still supports 32 and 33, see lib/Service/GlobalScaleService.php
@@ -203,7 +205,13 @@ class Application extends App implements IBootstrap {
 
 		// We should ignore oauth2 token endpoint (oauth can send the credentials as basic auth which will fail with apache auth)
 		$uri = $request->getPathInfo();
-		if (str_starts_with($uri, '/apps/oauth/api/v1/token') || str_starts_with($uri, '/apps/oauth2/authorize') || str_starts_with($uri, '/login/flow')) {
+		if (str_starts_with($uri, '/apps/oauth/api/v1/token')
+			|| str_starts_with($uri, '/apps/oauth2/authorize')
+			|| str_starts_with($uri, '/apps/globalsiteselector/autologout')
+			|| str_starts_with($uri, '/apps/user_saml/saml/sls')
+			|| str_starts_with($uri, '/apps/user_oidc/sls')
+			|| str_starts_with($uri, '/login/flow')
+		) {
 			return;
 		}
 

--- a/lib/ConfigLexicon.php
+++ b/lib/ConfigLexicon.php
@@ -32,7 +32,7 @@ class ConfigLexicon implements ILexicon {
 	public function getAppConfigs(): array {
 		return [
 			new Entry(key: self::GS_TOKENS, type: ValueType::ARRAY, defaultRaw: [], definition: 'list of token+host to navigate through GlobalScale', lazy: true),
-			new Entry(key: self::LOCAL_TOKEN, type: ValueType::STRING, defaultRaw: '', definition: 'local token to id instance within GlobalScale', lazy: true),
+			new Entry(key: self::LOCAL_TOKEN, type: ValueType::STRING, defaultRaw: '', definition: 'local token to id instance within GlobalScale'),
 			new Entry(key: self::REDIRECT_WEBDAV, type: ValueType::BOOL, defaultRaw: false, definition: 'redirect WebDAV request on Master to Slaves', lazy: false),
 		];
 	}


### PR DESCRIPTION
- 2.8.x lock logout and keep redirecting to slave.
- register `ConfigLexicon`
- remove lazy flag on gss token as it is loaded with public capabilities